### PR TITLE
Fix FAQ container rendering

### DIFF
--- a/001_conference_rooms.md
+++ b/001_conference_rooms.md
@@ -16,7 +16,7 @@ nav-menu: true
 		
 <!-- Elements -->
 <div class="row 200%">
-	<div class="5u 12u$(medium)">
+        <div class="5u 12u$(medium)" markdown="1">
 	<h2 id="elements">Conference Room Access</h2>
 <!-- Text stuff -->
 

--- a/002_virtual_offices.md
+++ b/002_virtual_offices.md
@@ -12,7 +12,7 @@ form: https://docs.google.com/forms/d/e/1FAIpQLSeBAYFz5YW3e1mocfJeqomSTUpgZgyFGB
 
 	<div class="inner">
         <div class="row 200%">
-            <div class="5u 12u$(medium)">
+            <div class="5u 12u$(medium)" markdown="1">
                 <h2 id="elements">Register a Virtual Office</h2>
 		<p><strong>What is a virtual office?</strong></p>
 		<p>A virtual office provides you all the benefits of a physical office without having to provision dedicated seating capacity. <br>

--- a/003_private_cabins.md
+++ b/003_private_cabins.md
@@ -14,7 +14,7 @@ nav-menu: true
 <section id="one">
 	<div class="inner">
         <div class="row 200%">
-            <div class="5u 12u$(medium)">
+            <div class="5u 12u$(medium)" markdown="1">
             <h2 id="elements">Private Cabins</h2>
                 <ul>
 		<li>43works has plug and playd cabins, with capcity from 2 to 7 seaters.</li>


### PR DESCRIPTION
## Summary
- allow Markdown inside the FAQ column on the conference rooms, virtual offices and private cabins pages

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_b_68602e83c3e48330b51d37f6498ed159